### PR TITLE
Create Github Action to run Playwright tests for the web app

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -1,0 +1,47 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/web/**'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    defaults:
+      run:
+        working-directory: ./apps/web
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 9.11.0
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '23.1.0'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps
+      - name: Run Playwright tests
+        run: pnpm test
+
+      - name: Upload Playwright test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: ./apps/web/test-results
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # harmoni
 
+![Playwright Tests](https://github.com/jmagrippis/harmoni/actions/workflows/playwright.yaml/badge.svg)
+
 A playlist creation app, powered by AI


### PR DESCRIPTION
Fixes #10

Add a Github Action to run Playwright tests for the web app.

* **New Github Action Workflow**:
  - Create `apps/web/.github/workflows/playwright.yaml` to run Playwright tests.
  - Trigger the workflow on pull requests against `main` and on pushes to `main` when changes are detected in the `apps/web` directory.
  - Set up the job to run on `ubuntu-latest`.
  - Install dependencies using `pnpm install`.
  - Run Playwright tests using `pnpm test`.
  - On failure, retain video test outputs as artifacts.

* **README Update**:
  - Add a badge with the result of the new workflow.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jmagrippis/harmoni/pull/11?shareId=e87ea12c-8a34-47d2-8ce1-d5fc2fdadae6).